### PR TITLE
support Scala 2.13

### DIFF
--- a/shared/src/main/scala_2.13/minitest/api/compat.scala
+++ b/shared/src/main/scala_2.13/minitest/api/compat.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2016 by Alexandru Nedelcu.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minitest.api
+
+object compat {
+  type Context = scala.reflect.macros.whitebox.Context
+
+  def freshTermName[C <: Context](c: C)(s: String) =
+    c.universe.TermName(c.freshName(s))
+
+  def termName[C <: Context](c: C)(s: String) =
+    c.universe.TermName(s)
+
+  def typeCheck[C <: Context](c: C)(t: c.Tree) =
+    c.typecheck(t)
+
+  def resetLocalAttrs[C <: Context](c: C)(t: c.Tree): c.Tree =
+    c.untypecheck(t)
+
+  def setOrig[C <: Context](c: C)(tt: c.universe.TypeTree, t: c.Tree) =
+    c.universe.internal.setOriginal(tt, t)
+}


### PR DESCRIPTION
the 2.13 effort is only just underway, but there is already a 2.13
community build and this change is needed for minitest to work
there

it would also be possible to jimmy the build to use the 2.12 directory
in the 2.13 case, or to add a symlink. I chose the copy-and-paste route