### PR TITLE
Add support for setupSuite and tearDownSuite

### DIFF
--- a/shared/src/main/scala/minitest/SimpleTestSuite.scala
+++ b/shared/src/main/scala/minitest/SimpleTestSuite.scala
@@ -36,7 +36,7 @@ trait SimpleTestSuite extends AbstractTestSuite with Asserts {
   lazy val properties: Properties[_] =
     synchronized {
       if (!isInitialized) isInitialized = true
-      Properties[Unit](() => (), _ => Void.UnitRef, propertiesSeq)
+      Properties[Unit](() => (), _ => Void.UnitRef, () => (), () => (), propertiesSeq)
     }
 
   private[this] var propertiesSeq = Seq.empty[TestSpec[Unit, Unit]]

--- a/shared/src/main/scala/minitest/TestSuite.scala
+++ b/shared/src/main/scala/minitest/TestSuite.scala
@@ -21,6 +21,8 @@ import minitest.api._
 import scala.concurrent.{ExecutionContext, Future}
 
 trait TestSuite[Env] extends AbstractTestSuite with Asserts {
+  def setupSuite(): Unit = ()
+  def tearDownSuite(): Unit = ()
   def setup(): Env
   def tearDown(env: Env): Unit
 
@@ -41,7 +43,7 @@ trait TestSuite[Env] extends AbstractTestSuite with Asserts {
   lazy val properties: Properties[_] =
     synchronized {
       if (!isInitialized) isInitialized = true
-      Properties(setup _, (env: Env) => { tearDown(env); Void.UnitRef }, propertiesSeq)
+      Properties(setup _, (env: Env) => { tearDown(env); Void.UnitRef }, setupSuite _, tearDownSuite _, propertiesSeq)
     }
 
   private[this] var propertiesSeq = Seq.empty[TestSpec[Env, Unit]]

--- a/shared/src/main/scala/minitest/api/Properties.scala
+++ b/shared/src/main/scala/minitest/api/Properties.scala
@@ -24,6 +24,8 @@ import minitest.api.Utils.silent
 case class Properties[I](
   setup: () => I,
   tearDown: I => Void,
+  setupSuite: () => Unit,
+  tearDownSuite: () => Unit,
   properties: Seq[TestSpec[I, Unit]])
   (implicit ec: ExecutionContext)
   extends Iterable[TestSpec[Unit, Unit]] {

--- a/shared/src/main/scala/minitest/runner/Task.scala
+++ b/shared/src/main/scala/minitest/runner/Task.scala
@@ -51,7 +51,10 @@ final class Task(task: TaskDef, cl: ClassLoader) extends BaseTask {
 
     val future = loadSuite(task.fullyQualifiedName(), cl).fold(unit) { suite =>
       loggers.foreach(_.info(Console.GREEN + task.fullyQualifiedName() + Console.RESET))
-      loop(suite.properties.iterator)
+      suite.properties.setupSuite()
+      loop(suite.properties.iterator).map { _ =>
+        suite.properties.tearDownSuite()
+      }
     }
 
     future.onComplete(_ => continuation(Array.empty))

--- a/shared/src/test/scala/minitest/tests/EnvironmentTest.scala
+++ b/shared/src/test/scala/minitest/tests/EnvironmentTest.scala
@@ -30,6 +30,12 @@ object EnvironmentTest extends TestSuite[Int] {
     assert(env > 0)
   }
 
+  override def setupSuite() = {
+  }
+
+  override def tearDownSuite() = {
+  }
+
   test("simple test") { env =>
     assertEquals(env, env)
   }


### PR DESCRIPTION
This is an extremely naive attempt at #7 

My use case is very similar to what described in #7 (setting up actor systems, database fixtures, and similar stuff that I would like to perform once per test suite).