### PR TITLE
Fix #27: Replace TestUtils with portable-scala-reflect.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,11 +160,14 @@ lazy val minitest = crossProject(JVMPlatform, JSPlatform, NativePlatform).in(fil
     ),
   )
   .platformsSettings(JVMPlatform, JSPlatform)(
+    libraryDependencies ++= Seq(
+      "org.portable-scala" %%% "portable-scala-reflect" % "0.1.0"
+    ),
     unmanagedSourceDirectories in Compile += {
       (baseDirectory in LocalRootProject).value / "jvm_js/src/main/scala"
     }
   )
-  .platformsSettings(JVMPlatform, NativePlatform)(
+  .platformsSettings(NativePlatform)(
     libraryDependencies ++= Seq(
       "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided"
     )

--- a/jvm_js/src/main/scala/minitest/Platform.scala
+++ b/jvm_js/src/main/scala/minitest/Platform.scala
@@ -17,7 +17,7 @@
 
 package minitest
 
-import org.scalajs.testinterface.TestUtils
+import org.portablescala.reflect.Reflect
 
 trait Platform {
   type Future[+A] = scala.concurrent.Future[A]
@@ -32,6 +32,13 @@ trait Platform {
 }
 
 object Platform extends Platform {
-  private[minitest] def loadModule(name: String, loader: ClassLoader): AnyRef =
-    TestUtils.loadModule(name, loader)
+  type EnableReflectiveInstantiation =
+    org.portablescala.reflect.annotation.EnableReflectiveInstantiation
+
+  private[minitest] def loadModule(name: String, loader: ClassLoader): Any = {
+    Reflect
+      .lookupLoadableModuleClass(name + "$", loader)
+      .getOrElse(throw new ClassNotFoundException(name))
+      .loadModule()
+  }
 }

--- a/native/src/main/scala/minitest/Platform.scala
+++ b/native/src/main/scala/minitest/Platform.scala
@@ -22,6 +22,9 @@ import scala.scalanative.testinterface.PreloadedClassLoader
 trait Platform
 
 object Platform extends Platform {
-  private[minitest] def loadModule(name: String, loader: ClassLoader): AnyRef =
+  type EnableReflectiveInstantiation =
+    scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+
+  private[minitest] def loadModule(name: String, loader: ClassLoader): Any =
     loader.asInstanceOf[PreloadedClassLoader].loadPreloaded(name)
 }

--- a/shared/src/main/scala/minitest/api/AbstractTestSuite.scala
+++ b/shared/src/main/scala/minitest/api/AbstractTestSuite.scala
@@ -17,7 +17,7 @@
 
 package minitest.api
 
-import scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
+import minitest.Platform.EnableReflectiveInstantiation
 
 @EnableReflectiveInstantiation
 trait AbstractTestSuite {


### PR DESCRIPTION
`TestUtils` is deprecated in Scala.js 0.6.25, and removed in Scala.js 1.0.0-M5. Its use cases are replaced by the more general https://github.com/portable-scala/portable-scala-reflect library.