### PR TITLE
Change output to use System.out.println directly

### DIFF
--- a/shared/src/main/scala/minitest/runner/ConsoleLogger.scala
+++ b/shared/src/main/scala/minitest/runner/ConsoleLogger.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2019 by The Minitest Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minitest.runner
+
+import sbt.testing.Logger
+
+final class ConsoleLogger extends Logger {
+  private[this] val withColors =
+    System.getenv().get("TERM") != null
+
+  def ansiCodesSupported(): Boolean =
+    withColors
+  def error(msg: String): Unit =
+    print(msg)
+  def warn(msg: String): Unit =
+    print(msg)
+  def info(msg: String): Unit =
+    print(msg)
+  def debug(msg: String): Unit =
+    print(msg)
+  def trace(t: Throwable): Unit =
+    t.printStackTrace(System.out)
+}

--- a/shared/src/main/scala/minitest/runner/Framework.scala
+++ b/shared/src/main/scala/minitest/runner/Framework.scala
@@ -23,13 +23,15 @@ import sbt.testing.{Framework => BaseFramework, _}
 class Framework extends BaseFramework {
   def name(): String = "minitest"
 
+  def options: Options = Options()
+
   def fingerprints(): Array[Fingerprint] =
     Array(ModuleFingerprint)
 
   def runner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader): Runner =
-    new minitest.runner.Runner(args, remoteArgs, testClassLoader)
+    new minitest.runner.Runner(args, remoteArgs, options, testClassLoader)
 
-  def slaveRunner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader, send: (String) => Unit): Runner =
+  def slaveRunner(args: Array[String], remoteArgs: Array[String], testClassLoader: ClassLoader, send: String => Unit): Runner =
     runner(args, remoteArgs, testClassLoader)
 }
 

--- a/shared/src/main/scala/minitest/runner/Options.scala
+++ b/shared/src/main/scala/minitest/runner/Options.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2019 by The Minitest Project Developers.
+ * Some rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package minitest.runner
+
+/**
+  * Configurable options for the runner.
+  */
+final case class Options(
+  /**
+    * Whether to use SBT's test-logging infrastructure, or just println.
+    *
+    * Defaults to println because SBT's test logging doesn't seem to give us
+    * anything that we want, and does annoying things like making a left-hand
+    * gutter and buffering input by default.
+    *
+    * Option inspired by its availability in uTest.
+    */
+  useSbtLogging: Boolean = true
+)

--- a/shared/src/main/scala/minitest/runner/Runner.scala
+++ b/shared/src/main/scala/minitest/runner/Runner.scala
@@ -22,22 +22,23 @@ import sbt.testing.{Runner => BaseRunner, Task => BaseTask, _}
 final class Runner(
   val args: Array[String],
   val remoteArgs: Array[String],
+  val options: Options,
   classLoader: ClassLoader)
   extends BaseRunner {
 
   def done(): String = ""
 
   def tasks(list: Array[TaskDef]): Array[BaseTask] = {
-    list.map(t => new Task(t, classLoader))
+    list.map(t => new Task(t, options, classLoader))
   }
 
   def receiveMessage(msg: String): Option[String] = {
     None
   }
 
-  def serializeTask(task: BaseTask, serializer: (TaskDef) => String): String =
+  def serializeTask(task: BaseTask, serializer: TaskDef => String): String =
     serializer(task.taskDef())
 
-  def deserializeTask(task: String, deserializer: (String) => TaskDef): BaseTask =
-    new Task(deserializer(task), classLoader)
+  def deserializeTask(task: String, deserializer: String => TaskDef): BaseTask =
+    new Task(deserializer(task), options, classLoader)
 }


### PR DESCRIPTION
The problem with `"org.scala-sbt" % "test-interface"` provided `Array[Logger]` is that those loggers are buffering the output, which isn't what we want because if a test freezes, there's no way to see which one froze.