### PR TITLE
Add assertDoesNotCompile, reimplement Await, prepare for release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,9 +29,19 @@ jobs:
           key: minitest-cache
 
       - run:
-          name: Compile and test project
+          name: Compile project for JVM / JS
           working_directory: ~/minitest
-          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m ci-all
+          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +clean +test:compile +package
+
+      - run:
+          name: Run tests for JVM / JS
+          working_directory: ~/minitest
+          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +test
+
+      - run:
+          name: Compile & Test project for Native
+          working_directory: ~/minitest
+          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +minitestNative/clean +minitestNative/test +minitestNative/package
 
       - save_cache:
           key: minitest-cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,14 +29,9 @@ jobs:
           key: minitest-cache
 
       - run:
-          name: Compile project
+          name: Compile and test project
           working_directory: ~/minitest
-          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +clean +test:compile +package
-
-      - run:
-          name: Run tests
-          working_directory: ~/minitest
-          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +test
+          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m ci-all
 
       - save_cache:
           key: minitest-cache

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minitest
 
-A mini testing framework cross-compiled for Scala 2.10, 2.11, 2.12,
+A mini testing framework cross-compiled for Scala 2.11, 2.12,
 2.13, [Scala.js 0.6.x](http://www.scala-js.org/) and
 [Scala Native 0.3.x](https://www.scala-native.org/).
 
@@ -12,7 +12,7 @@ For `build.sbt` (use the `%%%` operator for Scala.js):
 
 ```scala
 // use the %%% operator for Scala.js
-libraryDependencies += "io.monix" %% "minitest" % "2.5.0" % "test"
+libraryDependencies += "io.monix" %% "minitest" % "2.6.0" % "test"
 
 testFrameworks += new TestFramework("minitest.runner.Framework")
 ```
@@ -153,6 +153,56 @@ object MyLawsTest extends SimpleTestSuite with Checkers {
     check3((x: Int, y: Int, z: Int) => (x + y) + z == x + (y + z))
   }
 }
+```
+
+All available assertions are described in [minitest.api.Asserts](./shared/src/main/scala/minitest/api/Asserts.scala):
+
+```scala
+// Simple boolean testing
+assert(value == expected)
+
+// ... and with a message
+assert(value == expected, s"value: $value == expected $expected")
+
+// Equality testing
+assertEquals(value, expected)
+
+// Tests the result of an entire block of code
+assertResult("Hello, World!") {
+  Seq("Hello", "World").mkString(", ") + "!"
+}
+
+// ... and with a hint
+assertResult("Hello, World!", "No hello?!?") {
+  Seq("Hello", "World").mkString(", ") + "!"
+}
+
+// Tests that code throws some specific exception
+intercept[IllegalStateException] {
+  // ...
+  throw new IllegalStateException("boom!")
+}
+
+// Tests that a specific piece of code does not compile
+assertDoesNotCompile("1.noSuchMethod")
+
+// Tests that compilation fails for a piece of code with
+// a specific error message (via regular expression)
+assertDoesNotCompile("1.noSuchMethod", ".*?noSuchMethod is not a member of Int")
+
+// Ignores a piece of test, could be conditional
+if (isEnvironmentJavaScript) {
+  ignore("Test not available on top of JavaScript")
+}
+
+// Cancels a test — same as ignoring, but slightly different meaning;
+// same result though
+if (isEnvironmentJavaScript) {
+  cancel("Test cannot proceed on top of JavaScript")
+}
+
+// Fails a test immediately
+fail("Boom!")
 ```
 
 That's all you need to know.

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 import sbt.Keys._
 import com.typesafe.sbt.GitVersioning
 
-addCommandAlias("ci-all",  ";+clean ;+test:compile ;+test ;+package")
+addCommandAlias("ci-all",  ";+clean ;+test:compile; +minitestNative/test:compile ;+test ; +minitestNative/test ;+package")
 addCommandAlias("release", ";+clean ;+minitestNative/clean ;+publishSigned ;+minitestNative/publishSigned")
 
 val Scala211 = "2.11.12"
@@ -151,7 +151,7 @@ lazy val requiredMacroCompatDeps = Seq(
 )
 
 lazy val minitestRoot = project.in(file("."))
-  .aggregate(minitestJVM, minitestJS, minitestNative, lawsJVM, lawsJS, lawsNative, lawsLegacyJVM, lawsLegacyJS)
+  .aggregate(minitestJVM, minitestJS, lawsJVM, lawsJS, lawsNative, lawsLegacyJVM, lawsLegacyJS)
   .settings(
     name := "minitest root",
     Compile / sources := Nil,

--- a/jvm_js/src/main/scala/minitest/platform/package.scala
+++ b/jvm_js/src/main/scala/minitest/platform/package.scala
@@ -25,6 +25,8 @@ import org.portablescala.reflect.Reflect
  * utilities with a platform-specific implementation.
  */
 package object platform {
+  val Await = scala.concurrent.Await
+
   val DefaultExecutionContext = scala.concurrent.ExecutionContext.global
 
   type EnableReflectiveInstantiation =

--- a/native/src/main/scala/minitest/platform/Await.scala
+++ b/native/src/main/scala/minitest/platform/Await.scala
@@ -15,21 +15,21 @@
  * limitations under the License.
  */
 
-package minitest
+package minitest.platform
 
-import scala.concurrent.ExecutionContext
-import scala.scalanative.testinterface.PreloadedClassLoader
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
-package object platform {
-
-  val DefaultExecutionContext = new ExecutionContext {
-    def execute(runnable: Runnable): Unit = runnable.run()
-    def reportFailure(cause: Throwable): Unit = cause.printStackTrace()
+/**
+ * Stub needed because Scala Native's Await is not useful.
+ *
+ * Note that this isn't a proper `Await` implementation,
+ * just something very simple for compilation to work and
+ * to pass the current tests.
+ */
+object Await {
+  def result[A](future: Future[A], duration: Duration): A = {
+    scala.scalanative.runtime.loop()
+    future.value.get.get
   }
-
-  type EnableReflectiveInstantiation =
-    scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
-
-  private[minitest] def loadModule(name: String, loader: ClassLoader): Any =
-    loader.asInstanceOf[PreloadedClassLoader].loadPreloaded(name)
 }

--- a/shared/src/main/scala/minitest/api/Asserts.scala
+++ b/shared/src/main/scala/minitest/api/Asserts.scala
@@ -72,10 +72,10 @@ trait Asserts {
   }
 
   def assertDoesNotCompile(code: String): Unit =
-    macro Asserts.IllTypedMacros.applyImplNoExp
+    macro Asserts.DoesNotCompileMacros.applyImplNoExp
 
   def assertDoesNotCompile(code: String, expected: String): Unit =
-    macro Asserts.IllTypedMacros.applyImpl
+    macro Asserts.DoesNotCompileMacros.applyImpl
 
   def intercept[E <: Throwable : ClassTag](callback: => Unit)
     (implicit pos: SourceLocation): Unit = {
@@ -125,7 +125,10 @@ object Asserts extends Asserts {
     loop(0, tpl)
   }
 
-  class IllTypedMacros(val c: whitebox.Context) {
+  /**
+    * Shamelessly copied from Shapeless, copyright by Miles Sabin.
+    */
+  class DoesNotCompileMacros(val c: whitebox.Context) {
     import c.universe._
 
     def applyImplNoExp(code: Tree): Tree = applyImpl(code, null)

--- a/shared/src/main/scala/minitest/api/Asserts.scala
+++ b/shared/src/main/scala/minitest/api/Asserts.scala
@@ -18,8 +18,11 @@
 package minitest.api
 
 import java.util.regex.Matcher
+import java.util.regex.Pattern
+import scala.reflect.macros.{ whitebox, ParseException, TypecheckException }
 import scala.annotation.tailrec
 import scala.reflect.ClassTag
+import scala.language.experimental.macros
 
 trait Asserts {
   def assert(condition: => Boolean)(implicit pos: SourceLocation): Unit = {
@@ -68,6 +71,12 @@ trait Asserts {
         pos)
   }
 
+  def assertDoesNotCompile(code: String): Unit =
+    macro Asserts.IllTypedMacros.applyImplNoExp
+
+  def assertDoesNotCompile(code: String, expected: String): Unit =
+    macro Asserts.IllTypedMacros.applyImpl
+
   def intercept[E <: Throwable : ClassTag](callback: => Unit)
     (implicit pos: SourceLocation): Unit = {
 
@@ -114,5 +123,36 @@ object Asserts extends Asserts {
       }
 
     loop(0, tpl)
+  }
+
+  class IllTypedMacros(val c: whitebox.Context) {
+    import c.universe._
+
+    def applyImplNoExp(code: Tree): Tree = applyImpl(code, null)
+
+    def applyImpl(code: Tree, expected: Tree): Tree = {
+      val Literal(Constant(codeStr: String)) = code
+      val (expPat, expMsg) = expected match {
+        case null => (null, "Expected some error.")
+        case Literal(Constant(s: String)) =>
+          (Pattern.compile(s, Pattern.CASE_INSENSITIVE | Pattern.DOTALL), "Expected error matching: "+s)
+      }
+
+      try {
+        val dummy0 = TermName(c.freshName)
+        val dummy1 = TermName(c.freshName)
+        c.typecheck(c.parse(s"object $dummy0 { val $dummy1 = { $codeStr } }"))
+        c.error(c.enclosingPosition, "Type-checking succeeded unexpectedly.\n"+expMsg)
+      } catch {
+        case e: TypecheckException =>
+          val msg = e.getMessage
+          if((expected ne null) && !(expPat.matcher(msg)).matches)
+            c.error(c.enclosingPosition, "Type-checking failed in an unexpected way.\n"+expMsg+"\nActual error: "+msg)
+        case e: ParseException =>
+          c.error(c.enclosingPosition, s"Parsing failed.\n${e.getMessage}")
+      }
+
+      q"()"
+    }
   }
 }

--- a/shared/src/main/scala/minitest/runner/Task.scala
+++ b/shared/src/main/scala/minitest/runner/Task.scala
@@ -18,11 +18,11 @@
 package minitest.runner
 
 import minitest.api._
-import minitest.platform.loadModule
+import minitest.platform.{Await, loadModule}
 import sbt.testing.{Task => BaseTask, _}
 import scala.compat.Platform.EOL
 import scala.concurrent.duration.Duration
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.Try
 
 final class Task(task: TaskDef, opts: Options, cl: ClassLoader) extends BaseTask {

--- a/shared/src/test/scala/minitest/tests/DoesNotCompileTest.scala
+++ b/shared/src/test/scala/minitest/tests/DoesNotCompileTest.scala
@@ -1,0 +1,13 @@
+package minitest.tests
+
+import minitest.SimpleTestSuite
+
+object DoesNotCompileTest extends SimpleTestSuite {
+  test("assertDoesNotCompile(code)") {
+    assertDoesNotCompile("1.noSuchMethod")
+  }
+
+  test("assertDoesNotCompile(code, expected)") {
+    assertDoesNotCompile("1.noSuchMethod", ".*?noSuchMethod is not a member of Int")
+  }
+}


### PR DESCRIPTION
- Adding an `assertDoesNotCompile`, based on Shapeless's [illTyped](https://github.com/milessabin/shapeless/blob/master/core/src/main/scala/shapeless/test/typechecking.scala)
- Fixes `Await` for Scala Native, inspired by https://github.com/scala/nanotest-strawman/pull/16
- Prepares for release