### PR TITLE
Changes the signature of `intercept` to return the Throwable.

### DIFF
--- a/shared/src/main/scala/minitest/api/Asserts.scala
+++ b/shared/src/main/scala/minitest/api/Asserts.scala
@@ -78,7 +78,7 @@ trait Asserts {
     macro Asserts.DoesNotCompileMacros.applyImpl
 
   def intercept[E <: Throwable : ClassTag](callback: => Unit)
-    (implicit pos: SourceLocation): Unit = {
+    (implicit pos: SourceLocation): Throwable = {
 
     val E = implicitly[ClassTag[E]]
     try {
@@ -89,7 +89,7 @@ trait Asserts {
       case ex: InterceptException =>
         throw new AssertionException(ex.getMessage, pos)
       case ex: Throwable if E.runtimeClass.isInstance(ex) =>
-        () // Do nothing!
+        ex
     }
   }
 

--- a/shared/src/test/scala/minitest/tests/SimpleTest.scala
+++ b/shared/src/test/scala/minitest/tests/SimpleTest.scala
@@ -74,15 +74,17 @@ object SimpleTest extends SimpleTestSuite {
     intercept[AssertionException] {
       assertEquals("dummy", s)
     }
+    ()
   }
 
   test("intercept") {
-    class DummyException extends RuntimeException
+    class DummyException(message: String) extends RuntimeException(message)
     def test = 1
 
-    intercept[DummyException] {
-      if (test != 2) throw new DummyException
+    val ex = intercept[DummyException] {
+      if (test != 2) throw new DummyException("value was not equal to 2")
     }
+    assertEquals(ex.getMessage, "value was not equal to 2")
   }
 
   testAsync("asynchronous test") {
@@ -102,11 +104,13 @@ object SimpleTest extends SimpleTestSuite {
         if (hello(1) != 2) throw new DummyException
       }
     }
+    ()
   }
 
   test("fail()") {
     def x = 1
     intercept[AssertionException] { if (x == 1) fail() }
+    ()
   }
 
   test("fail(reason)") {


### PR DESCRIPTION
Returning the exception that was intercepted allows the library users to inspect the exception a little bit more, so they don't have to rely on just the expected type and can compare, as an example, the error message.

Would you prefer to have this new signature as a new function for compat issues maybe?