### PR TITLE
Cross-build for Scala.js 1.0/0.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # N.B. with 2.1 the webhook notification no longer works
-version: 2.0
+version: 2.1
 
 jobs:
   build:
@@ -9,6 +9,9 @@ jobs:
     environment:
       SBT_VERSION: 1.3.4
     resource_class: medium
+    parameters:
+      scalajsVersion:
+        type: string
     steps:
       - run:
           name: Install dependencies
@@ -31,12 +34,12 @@ jobs:
       - run:
           name: Compile project for JVM / JS
           working_directory: ~/minitest
-          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +clean +test:compile +package
+          command: cat /dev/null | SCALAJS_VERSION=<< parameters.scalajsVersion >> sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +clean +test:compile +package
 
       - run:
           name: Run tests for JVM / JS
           working_directory: ~/minitest
-          command: cat /dev/null | sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +test
+          command: cat /dev/null | SCALAJS_VERSION=<< parameters.scalajsVersion >> sbt -J-Xmx3072m -J-XX:MaxMetaspaceSize=1024m +test
 
       - run:
           name: Compile & Test project for Native
@@ -50,6 +53,20 @@ jobs:
             - "~/.sbt"
             - "~/.m2"
 
+build_jobs: &build_jobs
+  - build:
+      name:  Scala.js 0.6.x
+      scalajsVersion: 0.6.31
+  - build:
+      name:  Scala.js 1.x
+      scalajsVersion: 1.0.0
+
+workflows:
+  version: 2
+  
+  build:
+    jobs: *build_jobs
+    
 notify:
   webhooks:
     - url: https://webhooks.gitter.im/e/f1a7ec8fc9a34c6a9108

--- a/build.sbt
+++ b/build.sbt
@@ -153,7 +153,7 @@ lazy val requiredMacroCompatDeps = Seq(
 )
 
 lazy val minitestRoot = project.in(file("."))
-  .aggregate(minitestJVM, minitestJS, lawsJVM, lawsJS, lawsNative, lawsLegacyJVM, lawsLegacyJS)
+  .aggregate(minitestJVM, minitestJS, lawsJVM, lawsJS, lawsNative)
   .settings(
     name := "minitest root",
     Compile / sources := Nil,
@@ -225,37 +225,3 @@ lazy val laws = crossProject(JVMPlatform, JSPlatform, NativePlatform)
 lazy val lawsJVM    = laws.jvm
 lazy val lawsJS     = laws.js
 lazy val lawsNative = laws.native
-
-val LegacyScalaCheckVersion = Def.setting {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, v)) if v <= 12 =>
-      "1.13.5"
-    case _ =>
-      "1.14.0"
-  }
-}
-
-lazy val lawsLegacy = crossProject(JVMPlatform, JSPlatform)
-  .crossType(CrossType.Pure)
-  .in(file("laws-legacy"))
-  .dependsOn(minitest)
-  .settings(
-    name := "minitest-laws-legacy",
-    sharedSettings,
-    crossVersionSharedSources,
-    libraryDependencies ++= Seq(
-      "org.scalacheck" %%% "scalacheck" % LegacyScalaCheckVersion.value
-    ),
-    unmanagedSourceDirectories in Compile += {
-      baseDirectory.value.getParentFile / ".." / "laws" / "src" / "main" / "scala"
-    },
-    unmanagedSourceDirectories in Test += {
-      baseDirectory.value.getParentFile / ".." / "laws" / "src" / "test" / "scala"
-    }
-  )
-  .jsSettings(
-    scalaJSSettings
-  )
-
-lazy val lawsLegacyJVM = lawsLegacy.jvm
-lazy val lawsLegacyJS  = lawsLegacy.js

--- a/build.sbt
+++ b/build.sbt
@@ -174,7 +174,7 @@ lazy val minitest = crossProject(JVMPlatform, JSPlatform, NativePlatform).in(fil
   )
   .platformsSettings(JVMPlatform, JSPlatform)(
     libraryDependencies ++= Seq(
-      "org.portable-scala" %%% "portable-scala-reflect" % "0.1.0"
+      "org.portable-scala" %%% "portable-scala-reflect" % "1.0.0"
     ),
     unmanagedSourceDirectories in Compile += {
       (baseDirectory in LocalRootProject).value / "jvm_js/src/main/scala"
@@ -182,7 +182,7 @@ lazy val minitest = crossProject(JVMPlatform, JSPlatform, NativePlatform).in(fil
   )
   .platformsSettings(NativePlatform)(
     libraryDependencies ++= Seq(
-      "org.portable-scala" %% "portable-scala-reflect" % "0.1.0" % "provided"
+      "org.portable-scala" %% "portable-scala-reflect" % "1.0.0" % "provided"
     )
   )
   .jsSettings(
@@ -209,7 +209,7 @@ lazy val laws = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   )
   .platformsSettings(JVMPlatform, JSPlatform)(
     libraryDependencies ++= Seq(
-      "org.scalacheck" %%% "scalacheck" % "1.14.0"
+      "org.scalacheck" %%% "scalacheck" % "1.14.3"
     )
   )
   .nativeSettings(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-val crossProjVersion = "0.6.1"
+val crossProjVersion = "1.0.0"
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
 val scalaNativeVersion =
   Option(System.getenv("SCALANATIVE_VERSION")).getOrElse("0.3.9")
 


### PR DESCRIPTION
Adresses #43 

Blocks https://github.com/scopt/scopt/pull/280
<del>Blocked by https://github.com/typelevel/scalacheck/issues/629</del>

💥 Dropped legacy ScalaCheck 1.13.5 integration since ScalaCheck 1.13.5 is unlikely to be published for Scala.js 1.0, and Cats ecosystem have already moved on.
https://github.com/monix/minitest/pull/51#issuecomment-589557719
