### PR TITLE
Fix README example suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ object MySimpleSuite extends SimpleTestSuite {
     intercept[DummyException] {
       test()
     }
+    ()
   }
 
   test("test result of") {


### PR DESCRIPTION
[Version 2.8.0](https://github.com/monix/minitest/releases/tag/v2.8.0) (in f79c03e6a8b63f301e3b72913efd74c65a7957e2) changed the signature of `update` to return a `Throwable` instead of `Unit`. However, this change breaks the README example:

```scala
test("should throw") {
  class DummyException extends RuntimeException("DUMMY")
  def test(): String = throw new DummyException

  intercept[DummyException] {
    test()
  }
}
// [info] - should throw *** FAILED ***
// [info]   Problem with test spec, expecting `Unit`, but received: jsonrpc4s.tests.MySimpleSuite$DummyException$1: DUMMY  (MySimpleSuite.scala:18)
```

The workaround is to simply return `()`:

```scala
test("should throw") {
  class DummyException extends RuntimeException("DUMMY")
  def test(): String = throw new DummyException

  intercept[DummyException] {
    test()
  }
  ()
}
```