### PR TITLE
relax visibility of Dotty macros

### DIFF
--- a/shared/src/main/scala-3/minitest/macros/CompileMacros.scala
+++ b/shared/src/main/scala-3/minitest/macros/CompileMacros.scala
@@ -6,7 +6,7 @@ import scala.compiletime.testing._
 
 import minitest.api.{AssertionException, SourceLocation}
 
-private object CompileMacros {
+object CompileMacros {
   inline def doesNotCompile(inline code: String, expected: Option[String], pos: SourceLocation): Unit = {
       val errors = typeCheckErrors(code)
       if (errors.isEmpty)
@@ -22,7 +22,7 @@ private object CompileMacros {
   }
 }
 
-private[minitest] trait CompileMacros {
+trait CompileMacros {
   inline def assertDoesNotCompile(inline code: String)(implicit pos: SourceLocation): Unit =
     CompileMacros.doesNotCompile(code, Option.empty, pos)
 

--- a/shared/src/main/scala-3/minitest/macros/SourceLocationMacros.scala
+++ b/shared/src/main/scala-3/minitest/macros/SourceLocationMacros.scala
@@ -4,7 +4,7 @@ import scala.quoted._
 
 import minitest.api.SourceLocation
 
-private object SourceLocationMacros {
+object SourceLocationMacros {
   def impl()(using ctx: QuoteContext): Expr[SourceLocation] = {
     import qctx.tasty._
     val path = rootPosition.sourceFile.jpath
@@ -19,7 +19,7 @@ private object SourceLocationMacros {
   }
 }
 
-private[minitest] trait SourceLocationMacros {
+trait SourceLocationMacros {
   inline implicit def fromContext: SourceLocation =
     ${ SourceLocationMacros.impl() }
 }


### PR DESCRIPTION
Otherwise, this happens:

```
sbt:implicitbox root> test
[info] compiling 3 Scala sources to /home/lars/proj/monix/implicitbox/jvm/target/scala-3.0.0-M1/test-classes ...
[info] compiling 3 Scala sources to /home/lars/proj/monix/implicitbox/js/target/scala-3.0.0-M1/test-classes ...
[error] trait SourceLocationMacros cannot be accessed as a member of minitest.macros from module class NotSuite$.
```